### PR TITLE
Fix crash on SBCL when output file does not exist

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -266,10 +266,14 @@ nicknames."
     (find-package package-designator)))
 
 (defun file-mtime (pathname)
-  "Same as `file-write-date'.
+  "As `file-write-date', but check if the file exists first.
 This is provided in case we ever want to offer more precise timestamps
-on Lisp/OS/filesystem combinations that support it."
-  (cl:file-write-date pathname))
+on Lisp/OS/filesystem combinations that support it, and for
+implementations which signal an error rather than returning nil when
+PATHNAME does not exist."
+  (and
+   (cl:probe-file pathname)
+   (cl:file-write-date pathname)))
 
 (defmacro propagate-side-effect (&body body &environment env)
   "Force BODY to be evaluated both at compile time AND load time (but


### PR DESCRIPTION
It seems that SBCL signals an error from `cl:file-write-date` when the file in question does not exist, rather than returning `nil` as the spec seems to suggest (however ambiguously). This patch checks whether the file exists before opening it, which prevents building file targets from crashing when the output file(s) do not already exist.