### PR TITLE
Fix false style warning

### DIFF
--- a/stamp.lisp
+++ b/stamp.lisp
@@ -158,7 +158,7 @@ shadowed."
        (set :nsec 0)))))
 
 (defun target-timestamp= (ts1 ts2)
-  "Is TS1 greater than TS2?"
+  "Is TS1 equal to TS2?"
   (dispatch-case ((ts1 target-timestamp)
                   (ts2 target-timestamp))
     ((timestamp timestamp)

--- a/target.lisp
+++ b/target.lisp
@@ -1486,7 +1486,7 @@ exists, and as a non-existent prereq if TARGET does not exist."
           (assure stamp
             (funcall hash-fun val))))
     (unless (stamp= old-stamp new-stamp)
-      (unless (stamp= old-stamp never)
+      (unless (typep old-stamp 'never)
         (simple-style-warning "Redefining configuration ~s" name))
       (touch-target name new-stamp))
     val))


### PR DESCRIPTION
bumped into this, using `yesql`:

```
(yesql:import queries
  :from #p "src/sql/queries.sql"
  :as :cl-yesql/postmodern
  :prefix "Q/"
  :binding :all-functions)
  ```
  leads to an style-warning.
the reason is that `stamp=` explicitly states that `never != never` 

```
(defun stamp= (s1 s2)
  (dispatch-case ((s1 stamp)
                  (s2 stamp))
    ((target-timestamp target-timestamp)
     (target-timestamp= s1 s2))
....
(defun target-timestamp= (ts1 ts2)
  "Is TS1 greater than TS2?"
  (dispatch-case ((ts1 target-timestamp)
                  (ts2 target-timestamp))
    ((timestamp timestamp)
     (timestamp= ts1 ts2))
    ((timestamp universal-time)
     (= (timestamp-to-universal ts1) ts2))

    ((universal-time universal-time)
     (= ts1 ts2))
    ((universal-time timestamp)
     (= ts1 (timestamp-to-universal ts2)))

    ;; This might seem weird, but it's necessary for impossible
    ;; targets to always show up as changed, as well as for files that
    ;; have been deleted.
    ((never never) nil) ;; <- HERE
    ((far-future far-future) t)
    ((target-timestamp target-timestamp) nil)))

```

while `update-config-stamp` seems to be interested in whether the stamp changed from `never` to `something`

